### PR TITLE
Fixed password file name in polaric-password

### DIFF
--- a/polaric-passwd
+++ b/polaric-passwd
@@ -1,6 +1,6 @@
 #!/bin/bash
 DIR=/etc/polaric-aprsd
-if [ -e $DIR/users ]; then
+if [ -e $DIR/passwd ]; then
   htpasswd $DIR/passwd $1
 else
   htpasswd -c $DIR/passwd $1


### PR DESCRIPTION
The password file was overwritten each time. Now it works as intended.