### PR TITLE
GPS error handling

### DIFF
--- a/src/GpsPosition.java
+++ b/src/GpsPosition.java
@@ -132,7 +132,7 @@ public class GpsPosition extends OwnPosition
          String[] tok = p.split(",");
          if ( "$GPRMC".equals(tok[0])) 
              do_RMC(tok);
-	 else if ("$GPGGA".equals(tok[0])) {}
+         else if ("$GPGGA".equals(tok[0])) {}
 
     }
 


### PR DESCRIPTION
Reading the serial ports create some garbage. Some lines might be merged, and hence the checksumming goes wrong. Easily fixed by checking the lenght of the remaining input line.

Reading from serial might in some cases create an IOExcpetion with null bytes read. Ignore this exception, so not to stop further reading.

The GPRMC NMEA string has 13 fields. 

In theory, this should work. All testing indicates better performance, but I am unable to view the position on the map. My webapp2 might be uncompatible with latest aprsd since I get overlay map errors. Or there might be something else wrong with the libraries used to compile aprsd. In any case, these changes are necessary, and might explain why no-one has been able to get the GPS feature to work.