### PR TITLE
If a station's description is empty, then use the latest Status message

### DIFF
--- a/src/AprsParser.java
+++ b/src/AprsParser.java
@@ -145,9 +145,10 @@ public class AprsParser implements AprsChannel.Receiver
                 * The frame may be regarded as a status beacon. 
                 */
                if ("ID".equals(p.to) || "BEACON".equals(p.to))
+               {
+                  station.setTag("BEACON");
                   parseStatusReport(p, station, true);
-                
-                
+               }
         }
         } catch (NumberFormatException e) { 
             _api.log().debug("AprsParser", "Cannot parse number in input. Report string probably malformed"); 

--- a/src/Station.java
+++ b/src/Station.java
@@ -194,6 +194,12 @@ public class Station extends AprsPoint implements Serializable, Cloneable
         if (t==null)  
            t = new Date(); 
         _status = new Status(t, txt);
+        // If the station description is empty, then use the status
+       if ( ! hasDescr() )
+       {
+         setDescr(txt);
+       }
+
     }
     
     /* Vi kan kanskje legge inn en sjekk om statusrapporten er for gammel */


### PR DESCRIPTION
This way, we get a description for stations sending "ID" and "BEACON" frames.